### PR TITLE
page_repair: fix alignment assert for direct IO in PG16

### DIFF
--- a/page_repair/page_repair.c
+++ b/page_repair/page_repair.c
@@ -40,6 +40,12 @@ PG_MODULE_MAGIC;
 
 #define STANDBY_LSN_CHECK_INTERVAL (5 * 1000L) /* 5 sec */
 
+#ifdef pg_attribute_aligned
+	#define ALIGN_SIZE pg_attribute_aligned(PG_IO_ALIGN_SIZE)
+#else
+	#define ALIGN_SIZE
+#endif
+
 PGconn *conn = NULL;
 
 PG_FUNCTION_INFO_V1(pg_repair_page);
@@ -335,8 +341,8 @@ repair_page_internal(Oid oid, BlockNumber blkno, const char *forkname,
 	uint32		taghash;
 	LWLock		*partlock;
 	int			buf_id;
-	char		page[BLCKSZ];
-	char		standby_page[BLCKSZ];
+	char		page[BLCKSZ] ALIGN_SIZE;
+	char		standby_page[BLCKSZ] ALIGN_SIZE;
 	XLogRecPtr	target_lsn;
 
 	if (RecoveryInProgress())


### PR DESCRIPTION
Buffers need to be aligned by `PG_IO_ALIGN_SIZE` 

(see asserts` Assert((uintptr_t) buffer == TYPEALIGN(PG_IO_ALIGN_SIZE, buffer))` in  `md.c`)

Appears such error in TAP tests when compiled with asserts (`--enable-cassert`)

```
2024-07-01 20:52:35.942 UTC [2777151] 001_base.pl LOG:  statement: SELECT pg_repair_page('test', 0, 'port=51796 host=/tmp/Qi1_JV9BL4')
TRAP: failed Assert("(uintptr_t) buffer == TYPEALIGN(PG_IO_ALIGN_SIZE, buffer)"), File: "md.c", Line: 752, PID: 2777151
postgres: master: postgres postgres [local] SELECT(ExceptionalCondition+0x71)[0x5747f41e1201]
postgres: master: postgres postgres [local] SELECT(mdwrite+0x0)[0x5747f409d630]
/build/tmp_install/opt/tantor/db/16/lib/postgresql/page_repair.so(+0x311c)[0x741a6aa3111c]
/build/tmp_install/opt/tantor/db/16/lib/postgresql/page_repair.so(pg_repair_page+0x36)[0x741a6aa314a6]
postgres: master: postgres postgres [local] SELECT(+0x346c0c)[0x5747f3edac0c]
postgres: master: postgres postgres [local] SELECT(+0x37fbc5)[0x5747f3f13bc5]
postgres: master: postgres postgres [local] SELECT(standard_ExecutorRun+0x113)[0x5747f3edef33]
postgres: master: postgres postgres [local] SELECT(+0x51390f)[0x5747f40a790f]
postgres: master: postgres postgres [local] SELECT(PortalRun+0x197)[0x5747f40a8e97]
postgres: master: postgres postgres [local] SELECT(exec_simple_query+0x162)[0x5747f40a4c02]
postgres: master: postgres postgres [local] SELECT(PostgresMain+0x674)[0x5747f40a6e24]
postgres: master: postgres postgres [local] SELECT(+0x477b1f)[0x5747f400bb1f]
postgres: master: postgres postgres [local] SELECT(PostmasterMain+0xec8)[0x5747f400ccd8]
postgres: master: postgres postgres [local] SELECT(main+0x222)[0x5747f3d020d2]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3)[0x741a6da40083]
postgres: master: postgres postgres [local] SELECT(_start+0x2e)[0x5747f3d0274e]
```